### PR TITLE
Catch Twig_Error_Loader and return a 404 response instead

### DIFF
--- a/src/Controllers/ApiDocController.hh
+++ b/src/Controllers/ApiDocController.hh
@@ -2,6 +2,7 @@
 namespace Showcase\Controllers;
 
 use Plenty\Plugin\Controller;
+use Plenty\Plugin\Http\Response;
 use Plenty\Plugin\Templates\Twig;
 
 class ApiDocController extends Controller
@@ -15,9 +16,18 @@ class ApiDocController extends Controller
 		return $twig->render('PlentyPluginShowcase::api.classes');
 }
 
-	public function showApiModule(Twig $twig, string $module):string
+	public function showApiModule(Twig $twig, Response $response, string $module):mixed
 	{
-		return $twig->render('PlentyPluginShowcase::api.Modules.' . $module . '.classes');
+        try
+        {
+            $content = $twig->render('PlentyPluginShowcase::api.Modules.' . $module . '.classes');
+
+            return $content;
+        }
+        catch (\Exception $e)
+        {
+            return $response->make('', 404);
+        }
 	}
 
 }

--- a/src/Controllers/RestController.hh
+++ b/src/Controllers/RestController.hh
@@ -2,6 +2,7 @@
 namespace Showcase\Controllers;
 
 use Plenty\Plugin\Controller;
+use Plenty\Plugin\Http\Response;
 use Plenty\Plugin\Templates\Twig;
 
 class RestController extends Controller
@@ -9,17 +10,35 @@ class RestController extends Controller
 	/**
 	 *
 	 */
-	public function showRestModule(Twig $twig, string $moduleName):string
+	public function showRestModule(Twig $twig, Response $response, string $moduleName):mixed
 	{
-		return $twig->render('PlentyPluginShowcase::rest.intermediate_'.$moduleName);
+		try
+        {
+		    $content = $twig->render('PlentyPluginShowcase::rest.intermediate_'.$moduleName);
+
+            return $content;
+        }
+        catch (\Exception $e)
+        {
+            return $response->make('', 404);
+        }
 	}
 
 	/**
 	*
 	*/
-	public function showRestModuleDetail(Twig $twig, string $moduleName):string
+	public function showRestModuleDetail(Twig $twig, Response $response, string $moduleName):mixed
 	{
-		return $twig->render('PlentyPluginShowcase::rest.'.$moduleName);
+        try
+        {
+            $content = $twig->render('PlentyPluginShowcase::rest.'.$moduleName);
+
+            return $content;
+        }
+        catch (\Exception $e)
+        {
+            return $response->make('', 404);
+        }
 	}
 
 	public function showRestIntroduction(Twig $twig):string


### PR DESCRIPTION
Due to the generic routing, Requests to URLs like `/rest-doc/nonExistentPage` did not produce a 404 response, because the still fit the route spec (`'/rest-doc/{moduleName}'`), resulting in the Controller trying to render a non-existent Twig template, which lead to a response like this:

![bildschirmfoto 2016-10-06 um 17 58 22](https://cloud.githubusercontent.com/assets/17005834/19159989/8b908830-8bee-11e6-9134-2bfc9aefdf73.png)

Now, the controllers `try` to render the template, `catch` any Exceptions and return a 404 response instead, which in turn gets handled by the (mother-)application.

@plentymarkets/cms-frontend @plentymarkets/core 