### PR TITLE
ADD table with languages codes for REST API

### DIFF
--- a/resources/views/rest/introduction.twig
+++ b/resources/views/rest/introduction.twig
@@ -23,6 +23,9 @@
             </li>
         </ul>
     </div>
+    <div class="alert alert-info" role="alert">
+        <b>Note</b>: REST requests cannot be sent if your online store is locked.
+    </div>
 
     <h2 id="rest-authentication">Authentication</h2>
 
@@ -126,8 +129,102 @@
         <p>Click on the <b>REST</b> dropdown list, to access the pages that provide information on all resources currently available. Listed are the possible HTTP methods, the required parameters and the server response for each resource.
         </p>
     </div>
-    <div class="alert alert-info" role="alert">
-        <b>Note</b>: REST requests cannot be sent if your online store is locked.
+
+    <h2 id="languages">Language codes</h2>
+    <div class="api-docs-basics">
+        <p>
+            The following language codes are used in the plentymarkets REST API.
+        </p>
+
+        <table class="table table-striped table-responsive table-bordered table-hover">
+            <thead>
+            <tr>
+                <th>Code</th>
+                <th>Description</th>
+            </tr>
+            </thead>
+
+            <tbody>
+            <tr>
+                <td><b>bg</b></td>
+                <td>Bulgarian</td>
+            </tr>
+            <tr>
+                <td><b>cn</b></td>
+                <td>Chinese</td>
+            </tr>
+            <tr>
+                <td><b>cz</b></td>
+                <td>Czech</td>
+            </tr>
+            <tr>
+                <td><b>da</b></td>
+                <td>Danish</td>
+            </tr>
+            <tr>
+                <td><b>de</b></td>
+                <td>German</td>
+            </tr>
+            <tr>
+                <td><b>en</b></td>
+                <td>English</td>
+            </tr>
+            <tr>
+                <td><b>es</b></td>
+                <td>Spanish</td>
+            </tr>
+            <tr>
+                <td><b>fr</b></td>
+                <td>French</td>
+            </tr>
+            <tr>
+                <td><b>it</b></td>
+                <td>Italian</td>
+            </tr>
+            <tr>
+                <td><b>nl</b></td>
+                <td>Dutch</td>
+            </tr>
+            <tr>
+                <td><b>nn</b></td>
+                <td>Norwegian</td>
+            </tr>
+            <tr>
+                <td><b>pl</b></td>
+                <td>Polish</td>
+            </tr>
+            <tr>
+                <td><b>pt</b></td>
+                <td>Portuguese</td>
+            </tr>
+            <tr>
+                <td><b>ro</b></td>
+                <td>Romanian</td>
+            </tr>
+            <tr>
+                <td><b>ru</b></td>
+                <td>Russian</td>
+            </tr>
+            <tr>
+                <td><b>se</b></td>
+                <td>Swedish</td>
+            </tr>
+            <tr>
+                <td><b>sk</b></td>
+                <td>Slovak</td>
+            </tr>
+            <tr>
+                <td><b>tr</b></td>
+                <td>Turkish</td>
+            </tr>
+            <tr>
+                <td><b>vn</b></td>
+                <td>Vietnamese</td>
+            </tr>
+            </tbody>
+
+        </table>
     </div>
+
 
 {% endblock %}


### PR DESCRIPTION
@khoffmeister 
@srieseberg 
@awinzek 
@hschwab 

Mit folgendem HTML-Tag könnt ihr nun in REST-Texten (z.B. in Controllers oder Models -> Descriptions) auf Sprachkürzel verlinken:

In Models bitte folgenden Link verwenden:

`<a href="https://developers.plentymarkets.com/rest-doc/introduction#languages" target="_blank">LINK</a>`

In Controllers bitte folgenden Link verwenden:

`<a href='https://developers.plentymarkets.com/rest-doc/introduction#languages' target='_blank'>language</a>`

Unterschied sind die Double- bzw. Einfachquotes. Wenn der Link innerhalb einer description="..." liegt, dürfen nicht erneut Doublequotes folgen, sonst fliegt ein Fehler bei der Generierung.

Wenn ihr weitere Tabellen habt, die ihr auslagern möchtet, dann nutzt die letzte Tabelle auf folgender Seite als Vorlage und baut sie entweder selber ein oder schickt sie mir:
https://github.com/plentymarkets/plenty-plugin-showcase/blob/master/resources/views/rest/introduction.twig

