### PR TITLE
ADD marketplaceName

### DIFF
--- a/resources/views/content/devguide/docblocks/block_plugin_json.twig
+++ b/resources/views/content/devguide/docblocks/block_plugin_json.twig
@@ -11,6 +11,7 @@
     "type"              : "template",
     "version"           : "1.0.0",
     "license"           : "The license for the plugin",
+    "isClosedSource"    : "Determines if your plugin is closed source or open source",
     "pluginIcon"        : "The plugin icon",
     "price"             : 0.00,
     "description"       : "The description for your plugin",
@@ -79,6 +80,13 @@
             <tr>
                 <td>license</td>
                 <td>The license type for your plugin <span class="label label-danger">required</span></td>
+            </tr>
+            <tr>
+                <td>isClosedSource</td>
+                <td>The value of this field must be of type <code>bool</code>.<br />
+                    <strong>True:</strong> Makes the plugin code invisible to all customers who buy the plugin (closed source).<br />
+                    <strong>False:</strong> Makes the plugin code visible to all customers who buy the plugin (open source).<br /> 
+                    If no value is specified, the default value is set to <strong>false</strong>. <span class="label label-default">optional</span></td>
             </tr>
             <tr>
                 <td>pluginIcon</td>

--- a/resources/views/content/devguide/docblocks/block_plugin_json.twig
+++ b/resources/views/content/devguide/docblocks/block_plugin_json.twig
@@ -50,7 +50,7 @@
             </tr>
             <tr>
                 <td>marketplaceName</td>
-                <td>The name of your plugin which is displayed on the Marketplace. Specify an array for multiple languages, e.g. {"de":"German plugin name","en":"English plugin name"}. You can also set a general name for all languages in a single string: "Name for all languages". The name specified here will be displayed as the name for the item in the category item view and single item view. <span class="label label-danger">required</span></td>
+                <td>The name of your plugin which is displayed on the Marketplace. Specify an array for multiple languages, e.g. {"de":"German plugin name","en":"English plugin name"}. You can also set a general name for all languages in a single string: "Name for all languages". The name specified here will be displayed as the name for the item in the category item view and single item view. <span class="label label-default">optional</span></td>
             </tr>
             <tr>
                 <td>namespace</td>

--- a/resources/views/content/devguide/docblocks/block_plugin_json.twig
+++ b/resources/views/content/devguide/docblocks/block_plugin_json.twig
@@ -6,6 +6,7 @@
 <pre class="prettyprint lang-js grey-back linenums code-example">
 {
     "name"              : "PluginXY",
+    "marketplaceName"   : {"de":"German display name of plugin","en":"English display name of plugin"},
     "namespace"         : "XY",
     "type"              : "template",
     "version"           : "1.0.0",
@@ -46,6 +47,10 @@
             <tr>
                 <td>name</td>
                 <td>The name of your plugin. The plugin name must not yet exist in plentyMarketplace. The name must not contain spaces or special characters, must start with a character and must be written in <code>UpperCamelCase</code>. <span class="label label-danger">required</span></td>
+            </tr>
+            <tr>
+                <td>marketplaceName</td>
+                <td>The name of your plugin which is displayed on the Marketplace. Specify an array for multiple languages, e.g. {"de":"German plugin name","en":"English plugin name"}. You can also set a general name for all languages in a single string: "Name for all languages". The name specified here will be displayed as the name for the item in the category item view and single item view. <span class="label label-danger">required</span></td>
             </tr>
             <tr>
                 <td>namespace</td>

--- a/resources/views/content/marketplace/plugin-requirements.twig
+++ b/resources/views/content/marketplace/plugin-requirements.twig
@@ -91,7 +91,7 @@
                 The plugin information properties specified in the <code>plugin.json</code>:
                 <ul>
                     <li>
-                        name
+                        marketplaceName
                     </li>
                     <li>
                         version

--- a/resources/views/content/marketplace/plugin-requirements.twig
+++ b/resources/views/content/marketplace/plugin-requirements.twig
@@ -91,7 +91,7 @@
                 The plugin information properties specified in the <code>plugin.json</code>:
                 <ul>
                     <li>
-                        marketplaceName
+                        marketplaceName or name
                     </li>
                     <li>
                         version


### PR DESCRIPTION
FYI: Wir haben marketplaceName hinzugefügt, um Plugin-Namen in "Reinschrift" zu ermöglichen. Bitte prüfen und erst mergen, wenn die Funktion live ist. @GreniasNoTengo @tudor2004  @hschwab @timozenke 